### PR TITLE
feat: add extra_card() function to expose extra card fields

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Features:
  * Add Button to Center the loaded image in the Image Slice Window.
  * Add "Created At", "Last Modified At" columns to card list.
  * Add filter box to Game and Stylesheet selection.
+ * Add extra_card("field name") script function for accessing Extra Card Fields.
 
 ------------------------------------------------------------------------------
 HEAD: new items added as changes are made

--- a/doc/function/extra_data.txt
+++ b/doc/function/extra_data.txt
@@ -1,0 +1,27 @@
+Function: extra_data
+
+DOC_MSE_VERSION: since 2.2.0
+
+--Usage--
+> extra_data("field_name")
+
+Access the value of extra card fields.
+
+Due to lazy initialization of stylesheet specific Extra Card Fields they are not exposed directly from the card using `card.field_name` syntax.
+As a workaround this function returns the Value of the specified field name for the active card using an access pattern that supports late resolution of the value for the active stylesheet.
+
+--Parameters--
+! Parameter	Type	Description
+| @input@	[[type:string]]	Field name, with or without underscores.
+
+--Examples--
+
+>extra card field:
+>	...
+>	name: my first extra field
+>
+>extra card field:
+>	...
+>	name: my second extra field
+>	script:
+>>		space_to_comma(extra_data("my first extra field")) + "!"

--- a/doc/function/index.txt
+++ b/doc/function/index.txt
@@ -66,6 +66,7 @@ These functions are built into the program, other [[type:function]]s can be defi
 | [[fun:process_english_hints]]				Process the hints left by english_ functions in a keyword's reminder text.
 	
 ! Fields and values			<<<
+| [[fun:extra_data]]	Access the value of extra card fields.
 | [[fun:combined_editor|forward_editor]]	Use one field to edit another.
 | [[fun:combined_editor]]		Use one field to edit multiple others.
 | [[fun:primary_choice]]		Return the top level choice chosen from a choice field.

--- a/src/script/functions/editor.cpp
+++ b/src/script/functions/editor.cpp
@@ -384,6 +384,22 @@ SCRIPT_FUNCTION(count_chosen) {
   }
 }
 
+// ----------------------------------------------------------------------------- : Extra Card Fields
+
+SCRIPT_FUNCTION(extra_data) {
+  SCRIPT_PARAM_C(String, input);
+  SCRIPT_PARAM_C(CardP, card);
+  SCRIPT_PARAM_C(StyleSheetP, stylesheet);
+
+  FOR_EACH(valueP, card->extraDataFor(*stylesheet)) {
+    if (valueP->fieldP->name == input) {
+      SCRIPT_RETURN(valueP);
+    }
+  }
+
+  return delay_error(ScriptErrorNoMember("extra_data()", input));
+}
+
 // ----------------------------------------------------------------------------- : Init
 
 void init_script_editor_functions(Context& ctx) {
@@ -396,4 +412,5 @@ void init_script_editor_functions(Context& ctx) {
   ctx.setVariable(_("exclusive_choice"),         script_exclusive_choice);
   ctx.setVariable(_("require_exclusive_choice"), script_require_exclusive_choice);
   ctx.setVariable(_("remove_choice"),            script_remove_choice);
+  ctx.setVariable(_("extra_data"),               script_extra_data);
 }

--- a/src/script/functions/editor.cpp
+++ b/src/script/functions/editor.cpp
@@ -391,8 +391,12 @@ SCRIPT_FUNCTION(extra_data) {
   SCRIPT_PARAM_C(CardP, card);
   SCRIPT_PARAM_C(StyleSheetP, stylesheet);
 
+  // Transform input to standard field name syntax.
+  // Other functions are doing lookups for ValuePs, which I assume is doing some of this automatically.
+  String canonical_field_name = canonical_name_form(input);
+
   FOR_EACH(valueP, card->extraDataFor(*stylesheet)) {
-    if (valueP->fieldP->name == input) {
+    if (valueP->fieldP->name == canonical_field_name) {
       SCRIPT_RETURN(valueP);
     }
   }


### PR DESCRIPTION
Still running through some stylesheet validations. 
Currently using the below stylesheet as a test bed. It covers multiple field types, derived fields from script evaluation, boolean evaluation of the retrieved value, and custom function usage.
Really not sure what else to test, but I'm hoping it's pretty safe since it is just returning a `ValueP`.

Also need to investigate what script dependencies is doing, the `combine` function has a block that seems to bind which particular fields it show re-evaluate after changes to? This might be just blanket declaring a dependency against the entire Card without that, which while not atrocious is probably inefficient.

https://github.com/haganbmj/MagicSetEditor2/blob/5840f6c4936f1e9ae74b98a4013d39e8aca0e2c0/src/script/functions/editor.cpp#L146

```
mse version:	2.0.0
game:			magic
short name:		Test Template
full name:		Test Shit Yo
icon:			card-sample.png
position hint:	100

depends on:		magic.mse-game

card width: 375
card height: 523
card dpi: 150



init script:
	guild_mana := { false }
	ancestral_mana := { false }

extra card field:
	type: text
	name: extra text field
	save value: true
	script: replace(value, match: "_", replace: "*")
extra card field:
	type: choice
	name: extra choice field
	save value: true
	choice: a
	choice: b
	choice: c
extra card field:
	type: boolean
	name: extra boolean field

extra card field:
	type: text
	name: extra boolean evaluated
	save value: false
	script: if extra_data("extra boolean field") then "true" else "false"
extra card field:
	type: text
	name: extra text field custom func
	# This makes use of a magic.mse-game defined function.
	script: space_to_comma(extra_data("extra_text_field"))
extra card field:
	type: text
	name: extra scripted field
	save value: false
	script: 
		extra_data("extra_text_field") + " / "
		+ extra_data("extra text field custom func") + " / "
		+ extra_data("extra_choice_field") + " / "
		+ extra_data("extra_boolean_field")
		+ " (" + extra_data("extra_boolean_evaluated") + ")"

extra card style:
	extra text field:
		left: 20
		top: 20
		width: 335
		height: 20
		font:
			name: MPlantin
			italic name: MPlantin-Italic
			size: 12
			scale down to: 6
			color: black
		alignment: middle left
		z index: 10
extra card style:
	extra choice field:
		left: 20
		top: 40
		width: 335
		height: 20
		font:
			name: MPlantin
			italic name: MPlantin-Italic
			size: 12
			scale down to: 6
			color: black
		alignment: middle left
		z index: 10
extra card style:
	extra boolean field:
		left: 20
		top: 60
		width: 335
		height: 20
		font:
			name: MPlantin
			italic name: MPlantin-Italic
			size: 12
			scale down to: 6
			color: black
		alignment: middle left
		z index: 10

extra card style:
	extra scripted field:
		left: 20
		top: 450
		width: 335
		height: 75
		font:
			name: MPlantin
			italic name: MPlantin-Italic
			size: 12
			color: black
		alignment: middle left
		z index: 10

```