### PR TITLE
misc: changes to internal image storage

### DIFF
--- a/src/gui/value/image.cpp
+++ b/src/gui/value/image.cpp
@@ -41,7 +41,8 @@ void ImageValueEditor::sliceImage(const Image& image) {
   AlphaMask mask;
   style().mask.getNoCache(options,mask);
   // slice
-  ImageSliceWindow s(wxGetTopLevelParent(&editor()), image, style().getSize(), mask);
+  RealSize desiredSliceSize = RealSize(style().getSize().width * 2, style().getSize().height * 2);
+  ImageSliceWindow s(wxGetTopLevelParent(&editor()), image, desiredSliceSize, mask);
   // clicked ok?
   if (s.ShowModal() == wxID_OK) {
     // store the image into the set

--- a/src/gui/value/image.cpp
+++ b/src/gui/value/image.cpp
@@ -46,7 +46,7 @@ void ImageValueEditor::sliceImage(const Image& image) {
   // clicked ok?
   if (s.ShowModal() == wxID_OK) {
     // store the image into the set
-    LocalFileName new_image_file = getLocalPackage().newFileName(field().name,_("")); // a new unique name in the package
+    LocalFileName new_image_file = getLocalPackage().newFileName(field().name,_(".png")); // a new unique name in the package
     Image img = s.getImage();
     img.SaveFile(getLocalPackage().nameOut(new_image_file), wxBITMAP_TYPE_PNG); // always use PNG images, see #69. Disk space is cheap anyway.
     addAction(value_action(valueP(), new_image_file));


### PR DESCRIPTION
Two goals here
- Change internal file format of images to `.png` for easier manual modification.
- Increase size of internal images for better resolution on scaled exports.

The former is pretty easy and seems safe enough, still poking around to see if there's anywhere that might create a problem.
The latter is a bit trickier. I can do a dumb change to double the desired size when the Slice Window loads, but that has a couple drawbacks.
1. It enlarges the slice window pane, which doesn't have a size limit and doesn't attempt to constrain the preview.
2. It unnecessarily upscales small images to 200% leading to (slightly) increased size when stored.
3. I don't like having a static scale to save with, it really could just look to store "as large as possible." This would help with any future exports at any size and help the issue of storing larger than source - though that plays into the next problem regardless...
4. MSE does visual transformations (like sharpening) on the image before it's stored, so this is done at whatever scale/resolution is used for storage. This changes behavior as a 100% export is now going to downscale its sharpen.