### PR TITLE
misc: store images internally with PNG extension for easier manual tinkering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Features:
  * Add filter box to Game and Stylesheet selection.
  * Add extra_card("field name") script function for accessing Extra Card Fields.
  * Add Clear button to console panel.
+ * Store images internally with PNG extension.
 
 ------------------------------------------------------------------------------
 HEAD: new items added as changes are made

--- a/src/gui/value/image.cpp
+++ b/src/gui/value/image.cpp
@@ -45,7 +45,7 @@ void ImageValueEditor::sliceImage(const Image& image) {
   // clicked ok?
   if (s.ShowModal() == wxID_OK) {
     // store the image into the set
-    LocalFileName new_image_file = getLocalPackage().newFileName(field().name,_("")); // a new unique name in the package
+    LocalFileName new_image_file = getLocalPackage().newFileName(field().name,_(".png")); // a new unique name in the package
     Image img = s.getImage();
     img.SaveFile(getLocalPackage().nameOut(new_image_file), wxBITMAP_TYPE_PNG); // always use PNG images, see #69. Disk space is cheap anyway.
     addAction(value_action(valueP(), new_image_file));


### PR DESCRIPTION
This _appears_ to be safe. This is just modifying where the image is initially named, everywhere else references it based off that - and the program has no issues that I can tell so far with loading internal files with their extensions because it just uses the field as it is stored.

People on Discord have been doing set modification using pngs for a while so that's some amount of experimenting with it already.