### PR TITLE
misc: change storage size of image slices

### DIFF
--- a/data/en.mse-locale/locale
+++ b/data/en.mse-locale/locale
@@ -521,8 +521,8 @@ label:
 	html export options:Export options
 	
 	# Image slicer
-	original:			Original:
-	result:				Result:
+	original:			Original (%s x %s):
+	result:				Result (%s x %s):
 	size:				Size
 	original size:			&Original Size
 	size to fit:			Size to &Fit

--- a/data/en.mse-locale/locale
+++ b/data/en.mse-locale/locale
@@ -620,6 +620,7 @@ button:
 	always:							Always
 	if internet connection exists:	If internet connection exists
 	never:							Never
+	internal image extension: Store images internally with extension
 	
 	# Column select
 	move up:			Move &Up

--- a/data/en.mse-locale/locale
+++ b/data/en.mse-locale/locale
@@ -487,12 +487,18 @@ label:
 	windows : Open sets
 	app language : Language of the user interface :
 	card display : Card Display
-	zoom : &Zoom :
-	export : &Export :
+	storage : Storage
+	zoom : &Zoom:
+	export : &Export:
+	scale : &Internal Scale:
 	percent of normal:	% of normal size
 	external programs:	External programs
 	apprentice:			&Apprentice:
 	apprentice exe:		Apprentice Executable
+	internal scale desc:
+		Scale to internally store card images at.
+		Changing this may impact how Sharpening looks.
+		Does not retroactively apply to existing images.
 	check at startup:	Check for new versions at startup
 	checking requires internet:
 		Checking for updates requires an internet connection.
@@ -676,6 +682,7 @@ title:
 	global:					Global
 	display:				Display
 	directories:			Directories
+	internal:               Internal
 	updates:				Updates
 	update check:			Update Check
 	locate apprentice:		Locate Apprentice

--- a/src/data/settings.cpp
+++ b/src/data/settings.cpp
@@ -173,6 +173,7 @@ Settings::Settings()
   , symbol_grid_snap     (false)
   , print_layout         (LAYOUT_NO_SPACE)
   , internal_scale       (1.0)
+  , internal_image_extension(true)
   #if USE_OLD_STYLE_UPDATE_CHECKER
   , updates_url          (_("http://magicseteditor.sourceforge.net/updates"))
   #endif
@@ -260,6 +261,7 @@ IMPLEMENT_REFLECTION_NO_SCRIPT(Settings) {
   REFLECT(print_layout);
   REFLECT(apprentice_location);
   REFLECT(internal_scale);
+  REFLECT(internal_image_extension);
   #if USE_OLD_STYLE_UPDATE_CHECKER
     REFLECT(updates_url);
   #else

--- a/src/data/settings.cpp
+++ b/src/data/settings.cpp
@@ -172,6 +172,7 @@ Settings::Settings()
   , symbol_grid          (true)
   , symbol_grid_snap     (false)
   , print_layout         (LAYOUT_NO_SPACE)
+  , internal_scale       (1.0)
   #if USE_OLD_STYLE_UPDATE_CHECKER
   , updates_url          (_("http://magicseteditor.sourceforge.net/updates"))
   #endif
@@ -258,6 +259,7 @@ IMPLEMENT_REFLECTION_NO_SCRIPT(Settings) {
   REFLECT(default_game);
   REFLECT(print_layout);
   REFLECT(apprentice_location);
+  REFLECT(internal_scale);
   #if USE_OLD_STYLE_UPDATE_CHECKER
     REFLECT(updates_url);
   #else

--- a/src/data/settings.hpp
+++ b/src/data/settings.hpp
@@ -195,6 +195,7 @@ public:
   
   // --------------------------------------------------- : Internal settings
   double internal_scale;
+  bool internal_image_extension;
 
   // --------------------------------------------------- : Update checking
   #if USE_OLD_STYLE_UPDATE_CHECKER

--- a/src/data/settings.hpp
+++ b/src/data/settings.hpp
@@ -193,6 +193,9 @@ public:
   // --------------------------------------------------- : Special game stuff
   String apprentice_location;
   
+  // --------------------------------------------------- : Internal settings
+  double internal_scale;
+
   // --------------------------------------------------- : Update checking
   #if USE_OLD_STYLE_UPDATE_CHECKER
     String updates_url;

--- a/src/gui/image_slice_window.cpp
+++ b/src/gui/image_slice_window.cpp
@@ -389,7 +389,10 @@ void ImageSlicePreview::update() {
 wxSize ImageSlicePreview::DoGetBestSize() const {
   // We know the client size we want, calculate the size that goes with that
   wxSize ws = GetSize(), cs = GetClientSize();
-  return slice.target_size + ws - cs;
+
+  // This just gets it back to 100% scale. Doesn't solve the sizing issue of the overall window.
+  // All the above are doing appears to be finding margins/borders and accounting for them on a fixed scale.
+  return slice.target_size / 2 + ws - cs;
 }
 
 void ImageSlicePreview::onPaint(wxPaintEvent&) {
@@ -414,6 +417,10 @@ void ImageSlicePreview::draw(DC& dc) {
     } else {
       bitmap = Bitmap(image);
     }
+
+    // Rescale the bitmap based on the available size.
+    auto available_size = DoGetBestSize();
+    bitmap = wxBitmap(bitmap.ConvertToImage().Scale(available_size.GetWidth(), available_size.GetHeight()));
   }
   if (bitmap.Ok()) {
     dc.DrawBitmap(bitmap, 0, 0);

--- a/src/gui/image_slice_window.cpp
+++ b/src/gui/image_slice_window.cpp
@@ -133,11 +133,11 @@ ImageSliceWindow::ImageSliceWindow(Window* parent, const Image& source, const wx
     // top row: image editors
     wxSizer* s2 = new wxBoxSizer(wxHORIZONTAL);
       wxSizer* s3 = new wxBoxSizer(wxVERTICAL);
-        s3->Add(new wxStaticText(this, wxID_ANY, _LABEL_("original")));
+        s3->Add(new wxStaticText(this, wxID_ANY, _LABEL_2_("original", to_string(slice.source.GetWidth()), to_string(slice.source.GetHeight()))));
         s3->Add(selector, 1, wxEXPAND | wxTOP, 4);
       s2->Add(s3, 1, wxEXPAND | wxALL, 4);
       wxSizer* s4 = new wxBoxSizer(wxVERTICAL);
-        s4->Add(new wxStaticText(this, wxID_ANY, _LABEL_("result")));
+        s4->Add(new wxStaticText(this, wxID_ANY, _LABEL_2_("result", to_string(slice.target_size.GetWidth()), to_string(slice.target_size.GetHeight()))));
         s4->Add(preview, 0, wxTOP, 4);
       s2->Add(s4, 0, wxALL, 4);
     s->Add(s2, 1, wxEXPAND);
@@ -390,9 +390,12 @@ wxSize ImageSlicePreview::DoGetBestSize() const {
   // We know the client size we want, calculate the size that goes with that
   wxSize ws = GetSize(), cs = GetClientSize();
 
-  // This just gets it back to 100% scale. Doesn't solve the sizing issue of the overall window.
-  // All the above are doing appears to be finding margins/borders and accounting for them on a fixed scale.
-  return slice.target_size / 2 + ws - cs;
+  float target_ratio = ((float)slice.target_size.GetWidth()) / ((float)slice.target_size.GetHeight());
+  if (target_ratio > 1.0) {
+    return wxSize(500, 500 / target_ratio);
+  } else {
+    return wxSize(500 * target_ratio, 500);
+  }
 }
 
 void ImageSlicePreview::onPaint(wxPaintEvent&) {
@@ -475,7 +478,13 @@ ImageSliceSelector::ImageSliceSelector(Window* parent, int id, ImageSlice& slice
   , slice(slice)
   , mouse_down(false)
 {
-  SetMinSize(wxSize(400, 300));
+  
+  float target_ratio = ((float) slice.source.GetWidth()) / ((float) slice.source.GetHeight());
+  if (target_ratio > 1.0) {
+    SetMinSize(wxSize(500, 500 / target_ratio));
+  } else {
+    SetMinSize(wxSize(500 * target_ratio, 500));
+  }
   SetBackgroundStyle(wxBG_STYLE_PAINT);
 }
 

--- a/src/gui/preferences_window.cpp
+++ b/src/gui/preferences_window.cpp
@@ -75,6 +75,8 @@ public:
 private:
   DECLARE_EVENT_TABLE();
 
+  wxCheckBox* internal_image_extension;
+
   wxComboBox* internal_scale;
   int internal_scale_int;
 
@@ -313,7 +315,10 @@ END_EVENT_TABLE  ()
 // ----------------------------------------------------------------------------- : Preferences page : internal
 
 InternalPreferencesPage::InternalPreferencesPage(Window* parent) : PreferencesPage(parent) {
+  internal_image_extension = new wxCheckBox(this, wxID_ANY, _BUTTON_("internal image extension"));
   internal_scale = new wxComboBox(this, ID_INTERNAL_SCALE);
+
+  internal_image_extension->SetValue(settings.internal_image_extension);
 
   internal_scale_int = static_cast<int>(settings.internal_scale * 100);
   internal_scale->SetValue(String::Format(_("%d%%"), internal_scale_int));
@@ -325,19 +330,22 @@ InternalPreferencesPage::InternalPreferencesPage(Window* parent) : PreferencesPa
 
   wxSizer* s = new wxBoxSizer(wxVERTICAL);
   wxSizer* s2 = new wxStaticBoxSizer(wxVERTICAL, this, _LABEL_("storage"));
-  wxSizer* s3 = new wxBoxSizer(wxHORIZONTAL);
-  s3->Add(new wxStaticText(this, wxID_ANY, _LABEL_("scale")), 0, wxALL & ~wxLEFT, 4);
-  s3->AddSpacer(2);
-  s3->Add(internal_scale);
-  s3->Add(new wxStaticText(this, wxID_ANY, _LABEL_("percent of normal")), 1, wxALL & ~wxRIGHT, 4);
-  s2->Add(s3);
-  s2->Add(new wxStaticText(this, wxID_ANY, _LABEL_("internal scale desc")), 0, wxALL & ~wxLEFT, 4);
+    wxSizer* s3 = new wxBoxSizer(wxHORIZONTAL);
+      s3->Add(new wxStaticText(this, wxID_ANY, _LABEL_("scale")), 0, wxALL & ~wxLEFT, 4);
+      s3->AddSpacer(2);
+      s3->Add(internal_scale);
+      s3->Add(new wxStaticText(this, wxID_ANY, _LABEL_("percent of normal")), 1, wxALL & ~wxRIGHT, 4);
+    s2->Add(s3);
+    s2->Add(new wxStaticText(this, wxID_ANY, _LABEL_("internal scale desc")), 0, wxALL & ~wxLEFT, 4);
+    s2->Add(internal_image_extension, 0, wxEXPAND | wxALL, 4);
   s->Add(s2, 0, wxEXPAND | wxALL, 8);
   s->SetSizeHints(this);
   SetSizer(s);
 }
 
 void InternalPreferencesPage::store() {
+  settings.internal_image_extension = internal_image_extension->GetValue();
+
   updateInternalScale();
   settings.internal_scale = internal_scale_int / 100.0;
 }
@@ -356,7 +364,7 @@ void InternalPreferencesPage::updateInternalScale() {
 }
 
 BEGIN_EVENT_TABLE(InternalPreferencesPage, wxPanel)
-EVT_COMBOBOX(ID_INTERNAL_SCALE, InternalPreferencesPage::onInternalScaleChange)
+  EVT_COMBOBOX(ID_INTERNAL_SCALE, InternalPreferencesPage::onInternalScaleChange)
 END_EVENT_TABLE()
 
 // ----------------------------------------------------------------------------- : Preferences page : directories

--- a/src/gui/value/image.cpp
+++ b/src/gui/value/image.cpp
@@ -41,7 +41,7 @@ void ImageValueEditor::sliceImage(const Image& image) {
   AlphaMask mask;
   style().mask.getNoCache(options,mask);
   // slice
-  RealSize desiredSliceSize = RealSize(style().getSize().width * 2, style().getSize().height * 2);
+  RealSize desiredSliceSize = RealSize(style().getSize().width * settings.internal_scale, style().getSize().height * settings.internal_scale);
   ImageSliceWindow s(wxGetTopLevelParent(&editor()), image, desiredSliceSize, mask);
   // clicked ok?
   if (s.ShowModal() == wxID_OK) {

--- a/src/gui/value/image.cpp
+++ b/src/gui/value/image.cpp
@@ -49,7 +49,7 @@ void ImageValueEditor::sliceImage(const Image& image) {
   // clicked ok?
   if (s.ShowModal() == wxID_OK) {
     // store the image into the set
-    LocalFileName new_image_file = getLocalPackage().newFileName(field().name,_(".png")); // a new unique name in the package
+    LocalFileName new_image_file = getLocalPackage().newFileName(field().name, settings.internal_image_extension ? _(".png") : _("")); // a new unique name in the package
     Image img = s.getImage();
     img.SaveFile(getLocalPackage().nameOut(new_image_file), wxBITMAP_TYPE_PNG); // always use PNG images, see #69. Disk space is cheap anyway.
     addAction(value_action(valueP(), new_image_file));

--- a/src/gui/value/image.cpp
+++ b/src/gui/value/image.cpp
@@ -41,7 +41,8 @@ void ImageValueEditor::sliceImage(const Image& image) {
   AlphaMask mask;
   style().mask.getNoCache(options,mask);
   // slice
-  ImageSliceWindow s(wxGetTopLevelParent(&editor()), image, style().getSize(), mask);
+  RealSize desiredSliceSize = RealSize(style().getSize().width * 2, style().getSize().height * 2);
+  ImageSliceWindow s(wxGetTopLevelParent(&editor()), image, desiredSliceSize, mask);
   // clicked ok?
   if (s.ShowModal() == wxID_OK) {
     // store the image into the set

--- a/src/gui/value/image.cpp
+++ b/src/gui/value/image.cpp
@@ -41,8 +41,11 @@ void ImageValueEditor::sliceImage(const Image& image) {
   AlphaMask mask;
   style().mask.getNoCache(options,mask);
   // slice
-  RealSize desiredSliceSize = RealSize(style().getSize().width * settings.internal_scale, style().getSize().height * settings.internal_scale);
-  ImageSliceWindow s(wxGetTopLevelParent(&editor()), image, desiredSliceSize, mask);
+  // Specify a desired size based on the stylesheet and a scale multiplier defined within the user's settings.
+  // Storing at a greater than 100% resolution allows for better exports >100%, but may change how images look when filters (sharpen) are applied.
+  // Additionally, this bloats the set file size as even under-resolution images are upscaled to the new minimum size.
+  RealSize desired_slice_size = RealSize(style().getSize().width * settings.internal_scale, style().getSize().height * settings.internal_scale);
+  ImageSliceWindow s(wxGetTopLevelParent(&editor()), image, desired_slice_size, mask);
   // clicked ok?
   if (s.ShowModal() == wxID_OK) {
     // store the image into the set

--- a/src/util/locale.hpp
+++ b/src/util/locale.hpp
@@ -87,7 +87,11 @@ String tr(const Package&, const String& subcat, const String& key, DefaultLocale
 #define _TOOLTIP_1_(s,a)  format_string(_TOOLTIP_(s), a)
 
 /// A localized string for tooltip labels, with 1 argument (printf style)
-#define _LABEL_1_(s,a)    format_string(_LABEL_(s),   a)
+#define _LABEL_1_(s,a)     format_string(_LABEL_(s),   a)
+/// A localized string for tooltip labels, with 2 argument (printf style)
+#define _LABEL_2_(s,a,b)   format_string(_LABEL_(s),   a, b)
+/// A localized string for tooltip labels, with 3 argument (printf style)
+#define _LABEL_3_(s,a,b,c) format_string(_LABEL_(s),   a, b, c)
 
 /// A localized string for button text, with 1 argument (printf style)
 #define _BUTTON_1_(s,a)    format_string(_BUTTON_(s), a)

--- a/src/util/window_id.hpp
+++ b/src/util/window_id.hpp
@@ -282,6 +282,8 @@ enum ControlID {
   ID_EXPORT_ZOOM_Y,
   ID_SHARPEN,
   ID_SHARPEN_AMOUNT,
+  // Internal window
+  ID_INTERNAL_SCALE,
   // Updates window
   ID_PACKAGE_LIST,
   ID_KEEP,


### PR DESCRIPTION
 I can do a dumb change to double the desired size when the Slice Window loads, but that has a couple drawbacks.

- It enlarges the slice window pane, which doesn't have a size limit and doesn't attempt to constrain the preview.
- It unnecessarily upscales small images to 200% leading to (slightly) increased size when stored.
- I don't like having a static scale to save with, it really could just look to store "as large as possible." This would help with any future exports at any size and help the issue of storing larger than source - though that plays into the next problem regardless...
- MSE does visual transformations (like sharpening) on the image before it's stored, so this is done at whatever scale/resolution is used for storage. This changes behavior as a 100% export is now going to downscale its sharpen. Which brings up the point that that's already happening at lower/higher resolutions in MSE anyways... Maybe this just needs to be a config option since I don't want to fix when the effects are applied.