### PR TITLE
fix: correct viewer rotation direction (fixes #9)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,9 @@ Features:
  * Impose some rudimentary constraints on the Image Slice Window's initial size.
  * Merge String capitilization changes by @SoaringMoon.
 
+Bug fixes:
+ * Make viewer image rotate button operate clockwise to match dropdown options.
+
 ------------------------------------------------------------------------------
 HEAD: new items added as changes are made
 ------------------------------------------------------------------------------

--- a/src/gui/set/cards_panel.cpp
+++ b/src/gui/set/cards_panel.cpp
@@ -313,7 +313,7 @@ void CardsPanel::onCommand(int id) {
     case ID_CARD_ROTATE_0: case ID_CARD_ROTATE_90: case ID_CARD_ROTATE_180: case ID_CARD_ROTATE_270: {
       StyleSheetSettings& ss = settings.stylesheetSettingsFor(set->stylesheetFor(card_list->getCard()));
       ss.card_angle.assign(
-          id == ID_CARD_ROTATE     ? sane_fmod(ss.card_angle() + 90, 360)
+          id == ID_CARD_ROTATE     ? fmod((360 - 90 + ss.card_angle()), 360)
         : id == ID_CARD_ROTATE_0   ? 0
         : id == ID_CARD_ROTATE_90  ? 90
         : id == ID_CARD_ROTATE_180 ? 180


### PR DESCRIPTION
Make the rotate button operate clockwise to match the order of the dropdown options.