### PR TITLE
fix: use canonical name for stylesheet settings (fixes #8)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,8 @@ Features:
  * Merge String capitilization changes by @SoaringMoon.
 
 Bug fixes:
- * Make viewer image rotate button operate clockwise to match dropdown options.
+ * Make viewer image rotate button operate clockwise to match dropdown options. (#9)
+ * Fix storage/retrieval of Stylesheet Settings when the stylesheet name includes spaces. (#8)
 
 ------------------------------------------------------------------------------
 HEAD: new items added as changes are made

--- a/src/data/settings.cpp
+++ b/src/data/settings.cpp
@@ -224,7 +224,9 @@ ColumnSettings& Settings::columnSettingsFor(const Game& game, const Field& field
   return cs;
 }
 StyleSheetSettings& Settings::stylesheetSettingsFor(const StyleSheet& stylesheet) {
-  StyleSheetSettingsP& ss = stylesheet_settings[stylesheet.name()];
+  // Use the canonical form here since the stylesheet name will be used as a stored key.
+  // This does introduce the possibility of collision if two stylesheets return the same value canonically, but I think that's just a necessary risk.
+  StyleSheetSettingsP& ss = stylesheet_settings[canonical_name_form(stylesheet.name())];
   if (!ss) ss = make_intrusive<StyleSheetSettings>();
   ss->useDefault(default_stylesheet_settings); // update default settings
   return *ss;


### PR DESCRIPTION
Originally was looking at modifying the way `name()` is generated on the stylesheet, but that's tied into the broader package ecosystem and this seemed far less risky since it's the defacto access pattern apparently since it handles defaulting values.

This applies both in the `%AppData%` program configuration (eg. Card Rotation) and in the output `set` files where it controls per-card style overrides and such.