### PR TITLE
fix: apply image scale after slice window to avoid mask issues

### DIFF
--- a/src/data/format/image.cpp
+++ b/src/data/format/image.cpp
@@ -34,7 +34,7 @@ private:
 
 Rotation UnzoomedDataViewer::getRotation() const {
   if (!stylesheet) stylesheet = set->stylesheet;
-  int export_zoom = settings.stylesheetSettingsFor(set->stylesheetFor(card)).export_zoom();
+  double export_zoom = settings.stylesheetSettingsFor(set->stylesheetFor(card)).export_zoom();
   bool use_viewer_rotation = !settings.stylesheetSettingsFor(set->stylesheetFor(card)).card_normal_export();
 
   if (use_viewer_rotation) {

--- a/src/gui/image_slice_window.cpp
+++ b/src/gui/image_slice_window.cpp
@@ -61,12 +61,13 @@ void ImageSlice::centerSelection() {
     }
 }
 
-Image ImageSlice::getSlice() const {
-  if (selection.width == target_size.GetWidth() && selection.height == target_size.GetHeight() && selection.x == 0 && selection.y == 0) {
+Image ImageSlice::getSlice(double scale) const {
+  wxSize scaled_target_size = target_size * scale;
+  if (selection.width == scaled_target_size.GetWidth() && selection.height == scaled_target_size.GetHeight() && selection.x == 0 && selection.y == 0) {
     // exactly the right size
     return source.GetSubImage(selection);
   }
-  Image target(target_size.GetWidth(), target_size.GetHeight(), false);
+  Image target(scaled_target_size.GetWidth(), scaled_target_size.GetHeight(), false);
   if (sharpen && sharpen_amount > 0 && sharpen_amount <= 100) {
     sharp_resample_and_clip(source, target, selection, sharpen_amount);
   } else {
@@ -195,8 +196,8 @@ void ImageSliceWindow::onOk(wxCommandEvent&) {
   EndModal(wxID_OK);
 }
 
-Image ImageSliceWindow::getImage() const {
-  return slice.getSlice();
+Image ImageSliceWindow::getImage(double scale) const {
+  return slice.getSlice(scale);
 }
 
 // ----------------------------------------------------------------------------- : ImageSliceWindow : Controls

--- a/src/gui/image_slice_window.hpp
+++ b/src/gui/image_slice_window.hpp
@@ -45,7 +45,7 @@ public:
   /// Attempt to center the current constraints
   void centerSelection();
   /// Get the sliced image
-  Image getSlice() const;
+  Image getSlice(double scale = 1.0) const;
   
   // Zoom factor
   inline double zoomX() const { return target_size.GetWidth()  / (double)selection.width;  }
@@ -63,7 +63,7 @@ public:
   ImageSliceWindow(Window* parent, const Image& source, const wxSize& target_size, const AlphaMask& target_mask);
   
   /// Return the sliced image
-  Image getImage() const;
+  Image getImage(double scale) const;
   
   // --------------------------------------------------- : Data
 private:

--- a/src/gui/value/image.cpp
+++ b/src/gui/value/image.cpp
@@ -41,16 +41,17 @@ void ImageValueEditor::sliceImage(const Image& image) {
   AlphaMask mask;
   style().mask.getNoCache(options,mask);
   // slice
-  // Specify a desired size based on the stylesheet and a scale multiplier defined within the user's settings.
-  // Storing at a greater than 100% resolution allows for better exports >100%, but may change how images look when filters (sharpen) are applied.
-  // Additionally, this bloats the set file size as even under-resolution images are upscaled to the new minimum size.
-  RealSize desired_slice_size = RealSize(style().getSize().width * settings.internal_scale, style().getSize().height * settings.internal_scale);
-  ImageSliceWindow s(wxGetTopLevelParent(&editor()), image, desired_slice_size, mask);
+  ImageSliceWindow s(wxGetTopLevelParent(&editor()), image, style().getSize(), mask);
   // clicked ok?
   if (s.ShowModal() == wxID_OK) {
     // store the image into the set
     LocalFileName new_image_file = getLocalPackage().newFileName(field().name, settings.internal_image_extension ? _(".png") : _("")); // a new unique name in the package
-    Image img = s.getImage();
+
+    // Specify a desired size based on the stylesheet and a scale multiplier defined within the user's settings.
+    // Storing at a greater than 100% resolution allows for better exports >100%, but may change how images look when filters (sharpen) are applied.
+    // It also disrupts some of the patterns in use for doing popout planeswalkers since you have to do the math at both scales.
+    // Additionally, this bloats the set file size as even under-resolution images are upscaled to the new minimum size.
+    Image img = s.getImage(settings.internal_scale);
     img.SaveFile(getLocalPackage().nameOut(new_image_file), wxBITMAP_TYPE_PNG); // always use PNG images, see #69. Disk space is cheap anyway.
     addAction(value_action(valueP(), new_image_file));
   }


### PR DESCRIPTION
![unknown](https://user-images.githubusercontent.com/15820761/178119960-885cfd0e-00e6-46fd-9a19-cc8b9fce66d8.png)

This is just me not knowing that MSE applies masks on the Image Slice Window. When it does it expects the mask and the target_size to match.
Rather than changing how the mask is drawn it's easer (and cleaner) to just apply the internal scale when the file is ready to be saved. The rescaling isn't applied until the very end, so it's easy enough to just hook into that and do it as the very last operation. I think I also see now how I'd want to go about doing "as big as possible" if I want to apply that. I think there might still be some concerns around sharpening, but that's probably just an acceptable issue.
It might also be worth moving the internal selector to this window since it doesn't necessarily need to be static for all cards.