### PR TITLE
fix: Add Cards toolbar submenu initial load content (fixes twanvl#153)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@ HEAD: new items added as changes are made
 
 Features:
 
+Bug fixes:
+ * Fix Add Cards toolbar not showing script multi-add functions on initial load (twanvl#153)
+
 ------------------------------------------------------------------------------
 version 2.2.0 (Unofficial), 2022-07-16
 ------------------------------------------------------------------------------

--- a/src/gui/set/cards_panel.cpp
+++ b/src/gui/set/cards_panel.cpp
@@ -154,7 +154,9 @@ void CardsPanel::onChangeSet() {
   ((wxMenu*)menuCard)->Insert(4,insertManyCardsMenu); // HACK: the position is hardcoded
   // also for the toolbar dropdown menu
   if (toolAddCard) {
-    toolAddCard->SetDropdownMenu(makeAddCardsSubmenu(true));
+    // Originally this was using the menu directly, but there are compatibility issues apparently.
+    // At this point it might be possible to just store a reference to the toolbar directly instead.
+    toolAddCard->GetToolBar()->SetDropdownMenu(ID_CARD_ADD, makeAddCardsSubmenu(true));
   }
 }
 
@@ -186,7 +188,7 @@ void CardsPanel::initUI(wxToolBar* tb, wxMenuBar* mb) {
   add_tool_tr(tb, ID_FORMAT_SYMBOL, "symbol", "symbols", false, wxITEM_CHECK);
   add_tool_tr(tb, ID_FORMAT_REMINDER, "reminder", "reminder_text", false, wxITEM_CHECK);
   tb->AddSeparator();
-  add_tool_tr(tb, ID_CARD_ADD, "card_add", "add_card", false, wxITEM_DROPDOWN);
+  toolAddCard = add_tool_tr(tb, ID_CARD_ADD, "card_add", "add_card", false, wxITEM_DROPDOWN);
   tb->SetDropdownMenu(ID_CARD_ADD, makeAddCardsSubmenu(true));
   add_tool_tr(tb, ID_CARD_REMOVE, "card_del", "remove_card");
   tb->AddSeparator();


### PR DESCRIPTION
This commit is what broke it, but it did so while referencing some cross platform incompatibility. I hope the method done by this fix avoids that compatibility issue.

And just realized that I forgot to link the commit mentioned in the commit message.
https://github.com/twanvl/MagicSetEditor2/commit/177cc254871740037a9f7e760fb99d5a24ce0fde