### PR TITLE
feat: script functions for generating and manipulating card images

### DIFF
--- a/data/ch-s.mse-locale/locale
+++ b/data/ch-s.mse-locale/locale
@@ -891,6 +891,8 @@ type:
 	keyword:		关键词
 	keywords:		关键词
 #_ADD	pack:			pack type
+#_ADD	card region:	card region
+#_ADD	card regions:	card regions
 	
 	# Symbol editor shapes
 	shape:			图形

--- a/data/ch-t.mse-locale/locale
+++ b/data/ch-t.mse-locale/locale
@@ -891,6 +891,8 @@ type:
 	keyword:		關鍵詞
 	keywords:		關鍵詞
 #_ADD	pack:			pack type
+#_ADD	card region:	card region
+#_ADD	card regions:	card regions
 	
 	# Symbol editor shapes
 	shape:			圖形

--- a/data/da.mse-locale/locale
+++ b/data/da.mse-locale/locale
@@ -891,6 +891,8 @@ type:
 	keyword:		keyword
 	keywords:		keywords
 	pack:			pack type
+	card region:	card region
+	card regions:	card regions
 	
 	# Symbol editor shapes
 	shape:			shape

--- a/data/de.mse-locale/locale
+++ b/data/de.mse-locale/locale
@@ -891,6 +891,8 @@ type:
 	keyword:		keyword
 	keywords:		keywords
 	pack:			pack type
+	card region:	card region
+	card regions:	card regions
 	
 	# Symbol editor shapes
 	shape:			shape

--- a/data/en.mse-locale/locale
+++ b/data/en.mse-locale/locale
@@ -891,6 +891,8 @@ type:
 	keyword:		keyword
 	keywords:		keywords
 	pack:			pack type
+	card region:	card region
+	card regions:	card regions
 	
 	# Symbol editor shapes
 	shape:			shape

--- a/data/es.mse-locale/locale
+++ b/data/es.mse-locale/locale
@@ -891,6 +891,8 @@ type:
 	keyword:		palabra clave
 	keywords:		palabras clave
 	pack:			mazo
+#_ADD	card region:	card region
+#_ADD	card regions:	card regions
 	
 	# Symbol editor shapes
 	shape:			forma

--- a/data/fr.mse-locale/locale
+++ b/data/fr.mse-locale/locale
@@ -898,6 +898,8 @@ type:
 	circle:			cercle
 	ellipse:		ellipse
 	pack:			type de pack
+#_ADD	card region:	card region
+#_ADD	card regions:	card regions
 	square:			carré
 	rectangle:		rectangle
 	triangle:		triangle

--- a/data/it.mse-locale/locale
+++ b/data/it.mse-locale/locale
@@ -891,6 +891,8 @@ type:
 	keyword:		parola-chiave
 	keywords:		parole chiave
 	pack:			tipo busta
+#_ADD	card region:	card region
+#_ADD	card regions:	card regions
 
 	# Symbol editor shapes
 	shape:			forma

--- a/data/jp.mse-locale/locale
+++ b/data/jp.mse-locale/locale
@@ -889,6 +889,8 @@ type:
 	keyword:		キーワード
 	keywords:		キーワード
 #_ADD	pack:			pack type
+#_ADD	card region:	card region
+#_ADD	card regions:	card regions
 	
 	# Symbol editor shapes
 	shape:			形

--- a/data/pl.mse-locale/locale
+++ b/data/pl.mse-locale/locale
@@ -924,6 +924,8 @@ type:
 	keyword:		słowo kluczowe (keyword)
 	keywords:		słowa kluczowe (keywords)
 	pack:			rodzaj paczki (pack type)
+#_ADD	card region:	card region
+#_ADD	card regions:	card regions
 	
 	# Symbol editor shapes
 	shape:			kształt

--- a/data/pt-br.mse-locale/locale
+++ b/data/pt-br.mse-locale/locale
@@ -891,6 +891,8 @@ type:
 	keyword:		palavra-chave
 	keywords:		palavras-chaves
 	pack:			tipo de pacote
+#_ADD	card region:	card region
+#_ADD	card regions:	card regions
 	
 	# Symbol editor shapes
 	shape:			forma

--- a/src/data/card_region.cpp
+++ b/src/data/card_region.cpp
@@ -1,0 +1,25 @@
+//+----------------------------------------------------------------------------+
+//| Description:  Magic Set Editor - Program to make Magic (tm) cards          |
+//| Copyright:    (C) Twan van Laarhoven and the other MSE developers          |
+//| License:      GNU General Public License 2 or later (see file COPYING)     |
+//+----------------------------------------------------------------------------+
+
+#include <util/prec.hpp>
+#include <data/card_region.hpp>
+
+CardRegion::CardRegion()
+  : name("")
+  , x(0.0)
+  , y(0.0)
+  , width(0)
+  , height(0)
+{}
+CardRegion::~CardRegion() {}
+
+IMPLEMENT_REFLECTION(CardRegion) {
+  REFLECT(name);
+  REFLECT(x);
+  REFLECT(y);
+  REFLECT(width);
+  REFLECT(height);
+}

--- a/src/data/card_region.hpp
+++ b/src/data/card_region.hpp
@@ -1,0 +1,34 @@
+//+----------------------------------------------------------------------------+
+//| Description:  Magic Set Editor - Program to make Magic (tm) cards          |
+//| Copyright:    (C) Twan van Laarhoven and the other MSE developers          |
+//| License:      GNU General Public License 2 or later (see file COPYING)     |
+//+----------------------------------------------------------------------------+
+
+#pragma once
+
+#include <util/prec.hpp>
+#include <util/reflect.hpp>
+#include <script/scriptable.hpp>
+
+DECLARE_POINTER_TYPE(CardRegion);
+
+class CardRegion : public IntrusivePtrBase<CardRegion> {
+public:
+	CardRegion();
+	virtual ~CardRegion();
+
+	String name;
+	double x, y;
+	int width, height;
+
+private:
+	DECLARE_REFLECTION();
+};
+
+inline String type_name(const CardRegion&) {
+	return _TYPE_("card region");
+}
+
+inline String type_name(const vector<CardRegionP>&) {
+	return _TYPE_("card regions");
+}

--- a/src/data/format/formats.hpp
+++ b/src/data/format/formats.hpp
@@ -100,10 +100,10 @@ void export_image(const SetP& set, const CardP& card, const String& filename);
 
 /// Generate a bitmap image of a card
 Bitmap export_bitmap(const SetP& set, const CardP& card);
+Bitmap export_bitmap(const SetP& set, const CardP& card, const double zoom, const Radians angle_radians);
 
 /// Export a set to Magic Workstation format
 void export_mws(Window* parent, const SetP& set);
 
 /// Export a set to Apprentice
 void export_apprentice(Window* parent, const SetP& set);
-

--- a/src/data/stylesheet.cpp
+++ b/src/data/stylesheet.cpp
@@ -98,6 +98,7 @@ IMPLEMENT_REFLECTION(StyleSheet) {
   REFLECT(card_height);
   REFLECT(card_dpi);
   REFLECT(card_background);
+  REFLECT(card_regions);
   REFLECT(init_script);
   // styling
   REFLECT(styling_fields);

--- a/src/data/stylesheet.hpp
+++ b/src/data/stylesheet.hpp
@@ -12,11 +12,16 @@
 #include <util/io/package.hpp>
 #include <util/real_point.hpp>
 #include <script/scriptable.hpp>
+// This isn't strictly needed for this file, 
+// but CardRegion needs to be referenced from _somewhere_ in the codebase for compilation reasons.
+// Eventually if somewhere else is using the type then this can be removed.
+#include <data/card_region.hpp>
 
 DECLARE_POINTER_TYPE(Game);
 DECLARE_POINTER_TYPE(StyleSheet);
 DECLARE_POINTER_TYPE(Field);
 DECLARE_POINTER_TYPE(Style);
+DECLARE_POINTER_TYPE(CardRegion);
 
 // ----------------------------------------------------------------------------- : StyleSheet
 
@@ -34,6 +39,7 @@ public:
   double card_height;        ///< The height of a card in pixels
   double card_dpi;        ///< The resolution of a card in dots per inch
   Color  card_background;      ///< The background color of cards
+  vector<CardRegionP> card_regions;
   /// The styling for card fields
   /** The indices should correspond to the card_fields in the Game */
   IndexMap<FieldP, StyleP> card_style;

--- a/src/gfx/generated_image.cpp
+++ b/src/gfx/generated_image.cpp
@@ -443,6 +443,17 @@ bool BuiltInImage::operator == (const GeneratedImage& that) const {
   return that2 && name == that2->name;
 }
 
+// ----------------------------------------------------------------------------- : ArbitraryImage
+
+Image ArbitraryImage::generate(const Options& opt) const {
+  return image;
+}
+bool ArbitraryImage::operator == (const GeneratedImage& that) const {
+  const ArbitraryImage* that2 = dynamic_cast<const ArbitraryImage*>(&that);
+  return that2 && image.IsSameAs(that2->image);
+}
+
+
 // ----------------------------------------------------------------------------- : SymbolToImage
 
 SymbolToImage::SymbolToImage(bool is_local, const LocalFileName& filename, Age age, const SymbolVariationP& variation)

--- a/src/gfx/generated_image.hpp
+++ b/src/gfx/generated_image.hpp
@@ -348,6 +348,19 @@ private:
   String name;
 };
 
+// ----------------------------------------------------------------------------- : Arbitrary
+
+class ArbitraryImage : public GeneratedImage {
+public:
+    inline ArbitraryImage(const Image image)
+        : image(image)
+    {}
+    Image generate(const Options& opt) const override;
+    bool operator == (const GeneratedImage& that) const override;
+private:
+    Image image;
+};
+
 // ----------------------------------------------------------------------------- : SymbolToImage
 
 /// Use a symbol as an image

--- a/src/script/functions/image.cpp
+++ b/src/script/functions/image.cpp
@@ -37,6 +37,18 @@ SCRIPT_FUNCTION(to_card_image) {
 
 // ----------------------------------------------------------------------------- : Image functions
 
+SCRIPT_FUNCTION(width_of) {
+  SCRIPT_PARAM(GeneratedImageP, input);
+  Image image = input->generate(GeneratedImage::Options());
+  SCRIPT_RETURN(image.GetWidth());
+}
+
+SCRIPT_FUNCTION(height_of) {
+  SCRIPT_PARAM(GeneratedImageP, input);
+  Image image = input->generate(GeneratedImage::Options());
+  SCRIPT_RETURN(image.GetHeight());
+}
+
 SCRIPT_FUNCTION(linear_blend) {
   SCRIPT_PARAM(GeneratedImageP, image1);
   SCRIPT_PARAM(GeneratedImageP, image2);
@@ -218,6 +230,8 @@ SCRIPT_FUNCTION(built_in_image) {
 void init_script_image_functions(Context& ctx) {
   ctx.setVariable(_("to_image"),         script_to_image);
   ctx.setVariable(_("to_card_image"),    script_to_card_image);
+  ctx.setVariable(_("width_of"),         script_width_of);
+  ctx.setVariable(_("height_of"),        script_height_of);
   ctx.setVariable(_("linear_blend"),     script_linear_blend);
   ctx.setVariable(_("masked_blend"),     script_masked_blend);
   ctx.setVariable(_("combine_blend"),    script_combine_blend);

--- a/src/script/functions/image.cpp
+++ b/src/script/functions/image.cpp
@@ -16,6 +16,7 @@
 #include <data/stylesheet.hpp>
 #include <data/symbol.hpp>
 #include <data/field/symbol.hpp>
+#include <data/format/formats.hpp>
 #include <gfx/generated_image.hpp>
 #include <render/symbol/filter.hpp>
 
@@ -26,6 +27,12 @@ void parse_enum(const String&, ImageCombine& out);
 SCRIPT_FUNCTION(to_image) {
   SCRIPT_PARAM_C(GeneratedImageP, input);
   return input;
+}
+
+SCRIPT_FUNCTION(to_card_image) {
+  SCRIPT_PARAM(Set*, set);
+  SCRIPT_PARAM(CardP, input);
+  return make_intrusive<ArbitraryImage>(export_bitmap(set, input).ConvertToImage());
 }
 
 // ----------------------------------------------------------------------------- : Image functions
@@ -210,6 +217,7 @@ SCRIPT_FUNCTION(built_in_image) {
 
 void init_script_image_functions(Context& ctx) {
   ctx.setVariable(_("to_image"),         script_to_image);
+  ctx.setVariable(_("to_card_image"),    script_to_card_image);
   ctx.setVariable(_("linear_blend"),     script_linear_blend);
   ctx.setVariable(_("masked_blend"),     script_masked_blend);
   ctx.setVariable(_("combine_blend"),    script_combine_blend);

--- a/src/script/functions/image.cpp
+++ b/src/script/functions/image.cpp
@@ -32,7 +32,16 @@ SCRIPT_FUNCTION(to_image) {
 SCRIPT_FUNCTION(to_card_image) {
   SCRIPT_PARAM(Set*, set);
   SCRIPT_PARAM(CardP, input);
-  return make_intrusive<ArbitraryImage>(export_bitmap(set, input).ConvertToImage());
+  SCRIPT_PARAM_DEFAULT(double, zoom, 100);
+  SCRIPT_PARAM_DEFAULT(Degrees, angle, 0);
+  SCRIPT_PARAM_DEFAULT(bool, use_user_settings, false);
+  if (use_user_settings) {
+    // Use the User's Preferences for Export Zoom and Angle settings.
+    return make_intrusive<ArbitraryImage>(export_bitmap(set, input).ConvertToImage());
+  } else {
+    // Use the provided (or defaulted) Zoom and Angle.
+    return make_intrusive<ArbitraryImage>(export_bitmap(set, input, (zoom / 100), deg_to_rad(angle)).ConvertToImage());
+  }
 }
 
 // ----------------------------------------------------------------------------- : Image functions


### PR DESCRIPTION
The ultimate goal here is both #32 and #33.

- Add `to_card_image(input, zoom, angle)` as a script function to allow for variable access to resolved card images. 
- Add `card_region` as a stylesheet property to define slice regions for a card.

Example of `card_region`

```
# within a `style`
card width: 400
card height: 600
card dpi: 150
card region:
	name: front
	x: 0
	y: 0
	width: 200
	height: 600
card region:
	name: back
	x: 200
	y: 0
	width: 200
	height: 600
```

- Add `width_of(input)` and `height_of(input)` script functions for accessing image width/height. 

Ideally I would want width/height to be properties, but the nature of images in MSE is that they don't have these values until drawn so this internally is having to draw the images. There's probably a better way around that by drawing intermediate layers and storing the values for property access, but haven't really sorted that out - nor did I find a good way to reflect the return value of a function as a property. Images right now don't have reflected properties at all.

---

I think next steps from here would be...

- Overload some image generation methods to permit being region aware and return a map of images keyed by their name. A complication there is going to be when/how to apply the slices while factoring in scale. The actual draw function can build subregions before apply the scale - but once you have the output it's a bit late. So that means digging all the way down into the draw functions again.
- `write_image_file()` could add a param then to be region aware and return a map of images.
- `to_card_image()` could do the same, rather then leaving it for the script writer to try and slice their own cards which would require math to adjust for scale factor.
- Enhance the Export behavior to have some kind of pattern for doing regions. This gets potentially tricky with single card exports where the use can specify the file name as it likely means either suffixing the file name provided (and thereby guessing at any kind of overwrite behavior) or generating multiple dialogs. Multi-Export would probably be easier to update.