### PR TITLE
feat: construction of new_card with images? (closes #36)

### DIFF
--- a/src/script/functions/construction.cpp
+++ b/src/script/functions/construction.cpp
@@ -14,7 +14,9 @@
 #include <data/field/choice.hpp>
 #include <data/field/package_choice.hpp>
 #include <data/field/color.hpp>
+#include <data/field/image.hpp>
 #include <data/game.hpp>
+#include <data/set.hpp>
 #include <data/card.hpp>
 #include <util/error.hpp>
 
@@ -45,6 +47,17 @@ SCRIPT_FUNCTION(new_card) {
       pvalue->package_name = v->toString();
     } else if (ColorValue* cvalue = dynamic_cast<ColorValue*>(value)) {
       cvalue->value = v->toColor();
+    } else if (ImageValue* ivalue = dynamic_cast<ImageValue*>(value)) {
+      SCRIPT_PARAM(Set*, set);
+      // If we're dealing with a String assume it's a filepath and try to load it then store it.
+      // TODO:
+      
+      // If we're dealing with an in-memory image, go ahead and store it to an internal file within the set.
+      if (v->type() == ScriptType::SCRIPT_IMAGE) {
+        LocalFileName new_image_file = set->newFileName(name, settings.internal_image_extension ? _(".png") : _(""));
+        v->toImage()->generate(GeneratedImage::Options()).SaveFile(set->nameOut(new_image_file), wxBITMAP_TYPE_PNG);
+        ivalue->filename = new_image_file;
+      }
     } else {
       throw ScriptError(format_string(_("Can not set value '%s', it is not of the right type"),name));
     }


### PR DESCRIPTION
So it's a bit of a hack stemming from card fields wanting to be primitive types (in this case a string filename), on top of that it wants the path to relative to the active set - so you _need_ a set to write image files against. That seems a bit contrary to how new_card wants to operate, but I might be understating its usefulness.