### PR TITLE
feat: restore locale level translations for other packages (fixes #41)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ HEAD: new items added as changes are made
 ------------------------------------------------------------------------------
 
 Features:
+ * Restore reading of package translations from top level locale file. (haganbmj#43)
+ * Bundle other locale files, provide English translations as fallback rather than just using the key name.
 
 Bug fixes:
 

--- a/src/data/field.hpp
+++ b/src/data/field.hpp
@@ -60,6 +60,7 @@ public:
   Alignment card_list_align;  ///< Alignment of the card list colummn.
   OptionalScript sort_script; ///< The script to use when sorting this, if not the value.
   Dependencies dependent_scripts; ///< Scripts that depend on values of this field
+  String package_relative_filename;
   
   /// Creates a new Value corresponding to this Field
   virtual ValueP newValue() = 0;

--- a/src/data/locale.cpp
+++ b/src/data/locale.cpp
@@ -120,6 +120,24 @@ String tr(const Package& pkg, const String& subcat, const String& key, DefaultLo
   return loc->tr(subcat, key, def);
 }
 
+String tr(const String& pkg_relative_filename, const String& key, DefaultLocaleFun def) {
+  if (!the_locale) return def(key);
+  SubLocaleP loc = the_locale->package_translations[pkg_relative_filename];
+  if (!loc) {
+    loc = find_wildcard_and_set(the_locale->package_translations, pkg_relative_filename);
+  }
+  return loc->tr(key, def);
+}
+
+String tr(const String& pkg_relative_filename, const String& subcat, const String& key, DefaultLocaleFun def) {
+  if (!the_locale) return def(key);
+  SubLocaleP loc = the_locale->package_translations[pkg_relative_filename];
+  if (!loc) {
+    loc = find_wildcard_and_set(the_locale->package_translations, pkg_relative_filename);
+  }
+  return loc->tr(subcat, key, def);
+}
+
 // ----------------------------------------------------------------------------- : LocalizedString
 
 String const& LocalizedString::get(String const& locale) const {

--- a/src/util/locale.hpp
+++ b/src/util/locale.hpp
@@ -51,10 +51,14 @@ String tr(LocaleCategory cat, const String& key, DefaultLocaleFun def = warn_and
 /// Translate 'key' in the for a Package using the current locale
 [[deprecated]]
 String tr(const Package&, const String& key, DefaultLocaleFun def);
+[[deprecated]]
+String tr(const String&, const String& key, DefaultLocaleFun def);
 
 /// Translate 'key' in the for a Package using the current locale
 [[deprecated]]
 String tr(const Package&, const String& subcat, const String& key, DefaultLocaleFun def);
+[[deprecated]]
+String tr(const String&, const String& subcat, const String& key, DefaultLocaleFun def);
 
 /// A localized string for menus
 #define _MENU_(s)    tr(LOCALE_CAT_MENU,      _(s))


### PR DESCRIPTION
This is only a partial fix though, it basically restores the old behavior as a default. That doesn't help though with flipping the definitions to get stuff out of the UI Locale file though. So that'll have to come next for allowing wildcard resolutions to be done from the game(?) or maybe locale extension files?