### PR TITLE
Fixed scrolled widgets not scrolling fully (or at all)

### DIFF
--- a/src/gui/control/gallery_list.cpp
+++ b/src/gui/control/gallery_list.cpp
@@ -73,14 +73,14 @@ void GalleryList::select(size_t item, size_t subcolumn, bool event) {
 
 void GalleryList::update() {
   // ensure selection is visible
-  SubColumn col = subcolumns[active_subcolumn];
+  /*SubColumn col = subcolumns[active_subcolumn];
   if (col.selection != NO_SELECTION) {
     if (itemStart(col.selection) < visible_start) {
       scrollTo(itemStart(col.selection), false);
     } else if (itemEnd(col.selection) > visibleEnd()) {
       scrollTo(itemEnd(col.selection) + visible_start - visibleEnd(), false);
     }
-  }
+  }*/
   updateScrollbar();
   Refresh(false);
   InvalidateBestSize();

--- a/src/gui/control/native_look_editor.hpp
+++ b/src/gui/control/native_look_editor.hpp
@@ -39,6 +39,9 @@ private:
   static const int label_margin = 10;
   int              label_width;
   
+  int cached_thumb_pos = 0;
+  int cached_scroll = 0;
+  
   DECLARE_EVENT_TABLE();
   
   void onSize(wxSizeEvent&);


### PR DESCRIPTION
Fixes the widget scrolling issue in [#46](https://github.com/haganbmj/MagicSetEditor2/issues/46#issue-1337835471) and an, as it turns out, unrelated issue that made it impossible to scroll the Styling Options list (on Linux, wx's GTK backend).

(Both were ultimately because the existing MSE code was actively preventing the scroll position from being set correctly.)