### PR TITLE
Fixed crash when 0 keywords match filter string in keyword panel

### DIFF
--- a/src/gui/control/item_list.cpp
+++ b/src/gui/control/item_list.cpp
@@ -180,15 +180,16 @@ void ItemList::refreshList(bool refresh_current_only) {
   // refresh
   // Note: Freeze/Thaw makes flicker worse
   long item_count = (long)sorted_list.size();
+  if (item_count == 0) {
+    Refresh();
+  } else {
   SetItemCount(item_count);
   // (re)select current item
   findSelectedItemPos();
   focusNone();
   focusSelectedItem(true);
   // refresh items
-  if (item_count == 0) {
-    Refresh();
-  } else {
+  
     RefreshItems(0, item_count - 1);
   }
 }

--- a/src/gui/control/keyword_list.cpp
+++ b/src/gui/control/keyword_list.cpp
@@ -54,6 +54,7 @@ void KeywordList::onChangeSet() {
 }
 
 void KeywordList::setFilter(const KeywordListFilterP& filter) {
+
   this->filter = filter;
   refreshList();
 }
@@ -191,6 +192,8 @@ int KeywordList::usage(const Keyword& kw) const {
 // ----------------------------------------------------------------------------- : KeywordList : Item text
 
 String KeywordList::OnGetItemText (long pos, long col) const {
+  if (sorted_list.size() == 0) return wxEmptyString;
+  
   const Keyword& kw = *getKeyword(pos);
   switch(col) {
     case 0:    return kw.keyword;
@@ -223,6 +226,7 @@ int KeywordList::OnGetItemImage(long pos) const {
 }
 
 wxListItemAttr* KeywordList::OnGetItemAttr(long pos) const {
+  if (sorted_list.size() == 0) return nullptr;
   // black for set keywords, grey for game keywords (uneditable)
   const Keyword& kw = *getKeyword(pos);
   if (!kw.fixed && kw.valid) return nullptr;


### PR DESCRIPTION
In the keyword panel, when entering a string in the filter box that produced 0 matching keywords, MSE immediately crashed (Segmentation fault, on Linux).

This was due to the keyword_list and item_list GUI control code assuming at least one item in the list, and attempting to access the first item even when the list is empty.

I have added the relevant if (size == 0) checks.