### PR TITLE
Fix the cross-thread message queue to actually act as a queue, not a stack

### DIFF
--- a/src/util/error.cpp
+++ b/src/util/error.cpp
@@ -176,7 +176,7 @@ void queue_message(MessageType type, String const& msg) {
   // Thread safety
   wxMutexLocker lock(crit_error_handling);
   // Only show errors in the main thread
-  message_queue.push_back(make_pair(type,msg));
+  message_queue.push_front(make_pair(type,msg));
 }
 
 void handle_error(const Error& e) {


### PR DESCRIPTION
The message queue used (only?) to display messages in the GUI script console panel uses a std::deque internally, and was putting messages into it and taking them out from _the same end_.

When messages were put into to the queue faster than they were taken out, it was therefore acting as a stack and printing batches of them in reverse order.