### PR TITLE
misc: increase stats column width by 50% (fixes #71)

### DIFF
--- a/src/gui/set/stats_panel.cpp
+++ b/src/gui/set/stats_panel.cpp
@@ -105,8 +105,7 @@ public:
     , prefered_dimension_count(dimension_count)
     , show_empty(show_empty)
   {
-    //item_size = wxSize(150, 23);
-    subcolumns[0].size = wxSize(140,23);
+    subcolumns[0].size = wxSize(210, 23);
     if (dimension_count > 0) {
       subcolumns[0].selection  = NO_SELECTION;
       subcolumns[0].can_select = false;


### PR DESCRIPTION
This isn't a great solution since it's still just a static number, but it does at least improve the situation a bit for now.

Before:
![image](https://github.com/haganbmj/MagicSetEditor2/assets/15820761/978fe35c-c251-48b4-af5e-a5f24e334cfb)

After:
![image](https://github.com/haganbmj/MagicSetEditor2/assets/15820761/068515e7-afc0-4dd9-990c-76775b924381)
