### PR TITLE
Update CMakeLists.txt to allow for static compilation | Update Readme.md | Update package.ps1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ Magic Set Editor changelog, for the details see `git log`
 ==============================================================================
 
 ------------------------------------------------------------------------------
-HEAD: new items added as changes are made
+version 2.5.0 (Unofficial), 2024-04-28
 ------------------------------------------------------------------------------
 
 Features:
@@ -13,6 +13,7 @@ Bug fixes:
  * Fixed crash when 0 keywords match filter string in keyword panel (@llemoi, haganbmj#57)
  * Correct "all images" filter when selecting files. (haganbmj#70)
  * Correct localization of strings on Print window.
+ * Fixed issue where "All Images" filter on the art picker was not showing .jpeg files (BaconCatBug)
 
 Internal:
  * Add Mac OS build resources (@halian, haganbmj#67, haganbmj#68)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 
-project(magicseteditor VERSION 2.4.0)
+project(magicseteditor VERSION 2.5.0)
 add_definitions(-DUNOFFICIAL_BUILD)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -25,6 +25,11 @@ if( NOT HUNSPELL_FOUND )
 		message("-- Found Hunspell at ${HUNSPELL_LIBRARIES}")
 	endif()
 endif()
+
+# You will most likely get a message about being unable to open hunspell-1.7.lib because pkgconf forgets to add the actual path to
+# HUNSPELL_LIBRARIES. If so, uncomment the below line and point it to the correct vcpkg root folder/library.
+#set(HUNSPELL_LIBRARIES "C:\\PATH\\TO\\ROOT\\vcpkg\\installed\\${VCPKG_TARGET_TRIPLET}\\lib\\hunspell-1.7.lib")
+message("-- Does this have a full path? If not, and it's just a file name, it's broken: Found Hunspell at ${HUNSPELL_LIBRARIES}")
 
 include_directories("${PROJECT_BINARY_DIR}/src")
 include_directories("${PROJECT_SOURCE_DIR}/src")
@@ -142,3 +147,6 @@ endif()
 
 # Test suite
 include(test/tests.cmake)
+
+# Debug Message
+message("-- Does this have a full path? If not, and it's just a file name, it's broken: Found Hunspell at ${HUNSPELL_LIBRARIES}")

--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ On windows, the program can be compiled with Visual Studio (recommended) or with
 
 ````
 .\vcpkg install pkgconf wxwidgets boost-smart-ptr boost-regex boost-logic boost-pool boost-iterator hunspell --triplet=x64-windows-static
-
+````
 and/or
-
+````
 .\vcpkg install pkgconf wxwidgets boost-smart-ptr boost-regex boost-logic boost-pool boost-iterator hunspell --triplet=x86-windows-static
-
+````
+````
 .\vcpkg integrate install
 ````
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Magic Set Editor, or MSE for short, is a program with which you can design your 
 
 More information on https://magicseteditor.boards.net/
 
+## Main Features in the Unofficial Branch
+ * Fixes the "All Image" art selector list to include .jpeg images.
+ * Allows for the option to remove aliasing on selected art by increasing the size of the stored images in the set file.
+ * Adds a text filter on the style tab for Stylesheet.
+ * Decouples the zoom and export scales.
+
+
 ## Dependencies
 
 The code depends on

--- a/README.md
+++ b/README.md
@@ -14,29 +14,30 @@ The code depends on
 ## Building on windows with Visual Studio
 
 On windows, the program can be compiled with Visual Studio (recommended) or with mingw-gcc.
-
- * Download and install [Visual Studio Community edition](https://visualstudio.microsoft.com/vs/community/)
+ * VS instructions up-to-date as of April 2024
+ * Download and install [Visual Studio Community Edition](https://visualstudio.microsoft.com/vs/community/)
  * Download and install [vcpkg](https://github.com/microsoft/vcpkg)
- * Use vcpkg to install wxwidgets, boost, hunspell
+ * Use vcpkg to install pkgconf, wxwidgets, boost, hunspell
 
 ````
-vcpkg install wxwidgets
-vcpkg install boost-smart-ptr
-vcpkg install boost-regex
-vcpkg install boost-logic
-vcpkg install boost-pool
-vcpkg install boost-iterator
-vcpkg install hunspell
-vcpkg integrate install
+.\vcpkg install pkgconf wxwidgets boost-smart-ptr boost-regex boost-logic boost-pool boost-iterator hunspell --triplet=x64-windows-static
+
+and/or
+
+.\vcpkg install pkgconf wxwidgets boost-smart-ptr boost-regex boost-logic boost-pool boost-iterator hunspell --triplet=x86-windows-static
+
+.\vcpkg integrate install
 ````
 
  * Then just use "Open Folder" from inside visual studio to open the Magic Set Editor source code root folder.
- * Select the configuration that you want to build, and hit F7.
+ * Select the configuration that you want to build (release x64-windows-static), and hit F7.
 
 Notes:
+ * You will most likely get a message about being unable to open hunspell-1.7.lib because pkgconf forgets to add the actual path to HUNSPELL_LIBRARIES. If so, uncomment the noted line in CMakeLists.txt (line 31) and point it to the root vcpkg installation to find the correct hunspell-1.7.lib file.
+
  * You may need to work around [this bug](https://github.com/microsoft/vcpkg/issues/4756) by replacing `$VCPATH\IDE\CommonExtensions\Microsoft\CMake\CMake\share\cmake-3.16\Modules\FindwxWidgets.cmake` with the file from  https://github.com/CaeruleusAqua/vcpkg-wx-find (`$VCPATH` is usually `C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7`)
- * vcpkg by default installs 32 bit versions of libraries, use `vcpkg install PACKAGENAME:x64-windows` if you want to enable a 64 bit build.
- * Similarly, to use a static build, use `vcpkg install PACKAGENAME:x32-windows-static`.
+ * vcpkg by default installs 32 bit versions of libraries, use `vcpkg install PACKAGENAME --triplet=x64-windows` if you want to enable a 64 bit build.
+ * Similarly, to use a static build, use `vcpkg install PACKAGENAME --triplet=x32-windows` or `vcpkg install PACKAGENAME -triplet=x64-windows-static`.
  
 For running tests you will also need to
  * Download and install perl (For example [Strawberry perl](http://strawberryperl.com/) or using [MSYS2](https://www.msys2.org/))

--- a/package.ps1
+++ b/package.ps1
@@ -53,7 +53,7 @@ Copy-Item ./out/build/x64-Release-static/magicseteditor-cli.exe ./out/temp/x64/ 
 #Copy-Item ./data/en.mse-locale/ ./out/temp/x64/data/en.mse-locale/ -Force -Recurse
 Copy-Item ./out/temp/data/ ./out/temp/x64/data/ -Force -Recurse
 
-7z a -tzip ./out/dist/MagicSetEditor-2.5.0-win64.zip ./out/temp/x64/**
+7z a -tzip ./out/dist/MagicSetEditor-2.5.0-unofficial-win64.zip ./out/temp/x64/**
 
 # Gather the relevant x86 files and Zip them.
 Copy-Item ./BUNDLED_README.txt ./out/temp/x86/README.txt -Force -Recurse
@@ -63,4 +63,4 @@ Copy-Item ./out/build/x86-Release-static/magicseteditor-cli.exe ./out/temp/x86/ 
 #Copy-Item ./data/en.mse-locale/ ./out/temp/x86/data/en.mse-locale/ -Force -Recurse
 Copy-Item ./out/temp/data/ ./out/temp/x86/data/ -Force -Recurse
 
-7z a -tzip ./out/dist/MagicSetEditor-2.5.0-win32.zip ./out/temp/x86/**
+7z a -tzip ./out/dist/MagicSetEditor-2.5.0-unofficial-win32.zip ./out/temp/x86/**

--- a/package.ps1
+++ b/package.ps1
@@ -53,7 +53,7 @@ Copy-Item ./out/build/x64-Release-static/magicseteditor-cli.exe ./out/temp/x64/ 
 #Copy-Item ./data/en.mse-locale/ ./out/temp/x64/data/en.mse-locale/ -Force -Recurse
 Copy-Item ./out/temp/data/ ./out/temp/x64/data/ -Force -Recurse
 
-7z a -tzip ./out/dist/MagicSetEditor-2.4.0-win64.zip ./out/temp/x64/**
+7z a -tzip ./out/dist/MagicSetEditor-2.5.0-win64.zip ./out/temp/x64/**
 
 # Gather the relevant x86 files and Zip them.
 Copy-Item ./BUNDLED_README.txt ./out/temp/x86/README.txt -Force -Recurse
@@ -63,4 +63,4 @@ Copy-Item ./out/build/x86-Release-static/magicseteditor-cli.exe ./out/temp/x86/ 
 #Copy-Item ./data/en.mse-locale/ ./out/temp/x86/data/en.mse-locale/ -Force -Recurse
 Copy-Item ./out/temp/data/ ./out/temp/x86/data/ -Force -Recurse
 
-7z a -tzip ./out/dist/MagicSetEditor-2.4.0-win32.zip ./out/temp/x86/**
+7z a -tzip ./out/dist/MagicSetEditor-2.5.0-win32.zip ./out/temp/x86/**

--- a/package.ps1
+++ b/package.ps1
@@ -1,6 +1,15 @@
 # Super basic build script for release versions.
 # Note the hardcoded version numbers which don't read from CMakeLists at all.
 
+# Set alias for 7zip
+$7zipPath = "$env:ProgramFiles\7-Zip\7z.exe"
+
+if (-not (Test-Path -Path $7zipPath -PathType Leaf)) {
+throw "7 zip file '$7zipPath' not found"
+}
+
+Set-Alias 7z $7zipPath
+
 # Cleanup and Recreate the working directories.
 Remove-Item .\out\temp -Recurse
 Remove-Item .\out\dist -Recurse
@@ -40,6 +49,7 @@ Copy-Item ./data/ko.mse-locale/		./out/temp/data/ko.mse-locale/ -Force -Recurse
 Copy-Item ./BUNDLED_README.txt ./out/temp/x64/README.txt -Force -Recurse
 Copy-Item ./out/build/x64-Release-static/magicseteditor.com ./out/temp/x64/ -Force -Recurse
 Copy-Item ./out/build/x64-Release-static/magicseteditor.exe ./out/temp/x64/ -Force -Recurse
+Copy-Item ./out/build/x64-Release-static/magicseteditor-cli.exe ./out/temp/x64/ -Force -Recurse
 #Copy-Item ./data/en.mse-locale/ ./out/temp/x64/data/en.mse-locale/ -Force -Recurse
 Copy-Item ./out/temp/data/ ./out/temp/x64/data/ -Force -Recurse
 
@@ -49,6 +59,7 @@ Copy-Item ./out/temp/data/ ./out/temp/x64/data/ -Force -Recurse
 Copy-Item ./BUNDLED_README.txt ./out/temp/x86/README.txt -Force -Recurse
 Copy-Item ./out/build/x86-Release-static/magicseteditor.com ./out/temp/x86/ -Force -Recurse
 Copy-Item ./out/build/x86-Release-static/magicseteditor.exe ./out/temp/x86/ -Force -Recurse
+Copy-Item ./out/build/x86-Release-static/magicseteditor-cli.exe ./out/temp/x86/ -Force -Recurse
 #Copy-Item ./data/en.mse-locale/ ./out/temp/x86/data/en.mse-locale/ -Force -Recurse
 Copy-Item ./out/temp/data/ ./out/temp/x86/data/ -Force -Recurse
 

--- a/src/gui/preferences_window.cpp
+++ b/src/gui/preferences_window.cpp
@@ -328,7 +328,7 @@ InternalPreferencesPage::InternalPreferencesPage(Window* parent) : PreferencesPa
   internal_scale_int = static_cast<int>(settings.internal_scale * 100);
   internal_scale->SetValue(String::Format(_("%d%%"), internal_scale_int));
 
-  int choices[] = { 100,200 };
+  int choices[] = { 100,200,300,400 };
   for (unsigned int i = 0; i < sizeof(choices) / sizeof(choices[0]); ++i) {
     internal_scale->Append(String::Format(_("%d%%"), choices[i]));
   }


### PR DESCRIPTION
Fixed CMakeLists.txt to allow for static compilation and added a workaround for broken Hunspell. Upped version number to 2.5.0

Updated Readme.md to include corrected compilation instructions for Visual Studio and Workarounds.

Updated package.ps1 to include the cli executable in the dist zips and upped the version number to 2.5.0

As I am now able to compile both the x86 and x64 builds statically, if you need/want me to compile them for release, I can do so, or you if you can let me know to go away that is fine too. :) 

Thank you for all the hard work.

