### PR TITLE
Fix single-line fields not scaling fonts

### DIFF
--- a/src/render/text/viewer.cpp
+++ b/src/render/text/viewer.cpp
@@ -472,7 +472,7 @@ void TextViewer::prepareLinesTryScales(RotatedDC& dc, const String& text, const 
   
   // Try the layout at the previous scale, this could give a quick upper bound
   elements.getCharInfo(dc, scale, chars);
-  bool fits = prepareLinesAtScale(dc, chars, style, false, lines);
+  bool fits = prepareLinesAtScale(dc, chars, style, !style.field().multi_line, lines);
   if (fits) {
     min_scale = scale;
     max_scale = min(max_scale, bound_on_max_scale(dc,style,lines,scale));
@@ -483,7 +483,7 @@ void TextViewer::prepareLinesTryScales(RotatedDC& dc, const String& text, const 
     vector<Line> lines_before;
     vector<CharInfo> chars_before;
     elements.getCharInfo(dc, scale, chars_before);
-    fits = prepareLinesAtScale(dc, chars_before, style, false, lines_before);
+    fits = prepareLinesAtScale(dc, chars_before, style, !style.field().multi_line, lines_before);
     if (fits) {
       // too bad
       swap(lines, lines_before);
@@ -502,7 +502,7 @@ void TextViewer::prepareLinesTryScales(RotatedDC& dc, const String& text, const 
     best_scale = scale = min_scale;
     chars.clear();
     elements.getCharInfo(dc, scale, chars);
-    prepareLinesAtScale(dc, chars, style, false, lines);
+    prepareLinesAtScale(dc, chars, style, !style.field().multi_line, lines);
     max_scale = min(max_scale, bound_on_max_scale(dc,style,lines,scale));
   }
   
@@ -520,7 +520,7 @@ void TextViewer::prepareLinesTryScales(RotatedDC& dc, const String& text, const 
     vector<Line> lines_try;
     vector<CharInfo> chars_try;
     elements.getCharInfo(dc, scale, chars_try);
-    fits = prepareLinesAtScale(dc, chars_try, style, false, lines_try);
+    fits = prepareLinesAtScale(dc, chars_try, style, !style.field().multi_line, lines_try);
     if (fits) {
       min_scale = scale;
       max_scale = min(max_scale, bound_on_max_scale(dc,style,lines_try,scale));
@@ -538,7 +538,7 @@ void TextViewer::prepareLinesTryScales(RotatedDC& dc, const String& text, const 
     scale = min_scale;
     chars.clear();
     elements.getCharInfo(dc, scale, chars);
-    fits = prepareLinesAtScale(dc, chars, style, false, lines);
+    fits = prepareLinesAtScale(dc, chars, style, !style.field().multi_line, lines);
   }
   scale = min_scale;
 }

--- a/src/render/text/viewer.cpp
+++ b/src/render/text/viewer.cpp
@@ -472,7 +472,8 @@ void TextViewer::prepareLinesTryScales(RotatedDC& dc, const String& text, const 
   
   // Try the layout at the previous scale, this could give a quick upper bound
   elements.getCharInfo(dc, scale, chars);
-  bool fits = prepareLinesAtScale(dc, chars, style, !style.field().multi_line, lines);
+  bool single_line = !style.field().multi_line;
+  bool fits = prepareLinesAtScale(dc, chars, style, single_line, lines);
   if (fits) {
     min_scale = scale;
     max_scale = min(max_scale, bound_on_max_scale(dc,style,lines,scale));
@@ -483,7 +484,7 @@ void TextViewer::prepareLinesTryScales(RotatedDC& dc, const String& text, const 
     vector<Line> lines_before;
     vector<CharInfo> chars_before;
     elements.getCharInfo(dc, scale, chars_before);
-    fits = prepareLinesAtScale(dc, chars_before, style, !style.field().multi_line, lines_before);
+    fits = prepareLinesAtScale(dc, chars_before, style, single_line, lines_before);
     if (fits) {
       // too bad
       swap(lines, lines_before);
@@ -502,7 +503,7 @@ void TextViewer::prepareLinesTryScales(RotatedDC& dc, const String& text, const 
     best_scale = scale = min_scale;
     chars.clear();
     elements.getCharInfo(dc, scale, chars);
-    prepareLinesAtScale(dc, chars, style, !style.field().multi_line, lines);
+    prepareLinesAtScale(dc, chars, style, single_line, lines);
     max_scale = min(max_scale, bound_on_max_scale(dc,style,lines,scale));
   }
   
@@ -520,7 +521,7 @@ void TextViewer::prepareLinesTryScales(RotatedDC& dc, const String& text, const 
     vector<Line> lines_try;
     vector<CharInfo> chars_try;
     elements.getCharInfo(dc, scale, chars_try);
-    fits = prepareLinesAtScale(dc, chars_try, style, !style.field().multi_line, lines_try);
+    fits = prepareLinesAtScale(dc, chars_try, style, single_line, lines_try);
     if (fits) {
       min_scale = scale;
       max_scale = min(max_scale, bound_on_max_scale(dc,style,lines_try,scale));
@@ -538,7 +539,7 @@ void TextViewer::prepareLinesTryScales(RotatedDC& dc, const String& text, const 
     scale = min_scale;
     chars.clear();
     elements.getCharInfo(dc, scale, chars);
-    fits = prepareLinesAtScale(dc, chars, style, !style.field().multi_line, lines);
+    fits = prepareLinesAtScale(dc, chars, style, single_line, lines);
   }
   scale = min_scale;
 }


### PR DESCRIPTION
TextViewer::prepareLinesAtScale has a parameter `stop_if_too_long` to help it decide when to shrink text, but this is always false for text fields that aren't multi line, so autoshrink fails to apply to them. this PR sets the intial param to true for single line fields so auto-shrink will kick in as long as `scale down to` is defined.

the instance on line 453 remains false; this is only called when `scale down to` is not defined so doing the same here would cause text not to render if it overflows, instead it continues the current behavior of squishing text horizontally.