### PR TITLE
Add exists_in_package script function

### DIFF
--- a/doc/function/exists_in_package.txt
+++ b/doc/function/exists_in_package.txt
@@ -1,0 +1,13 @@
+Function: exists_in_package
+
+--Usage--
+> exists_in_package("/package/filename")
+
+Check if a file exists in a given package.
+
+--Parameters--
+! Parameter	Type			Description
+| @input@	[[type:string]]		Path of the file, starting from the data directory.
+
+--Examples--
+> exists_in_package("/magic-modules.mse-include/watermarks/custom_user_watermark.png")  ==  true

--- a/doc/function/index.txt
+++ b/doc/function/index.txt
@@ -112,3 +112,4 @@ These functions are built into the program, other [[type:function]]s can be defi
 | [[fun:assert]]		Check a condition for debugging purposes.
 | [[fun:warning]]		Output a warning message.
 | [[fun:error]]			Output an error message.
+| [[fun:exists_in_package]]			Checks if a file exists in a package.

--- a/src/script/functions/basic.cpp
+++ b/src/script/functions/basic.cpp
@@ -13,6 +13,7 @@
 #include <util/tagged_string.hpp>
 #include <util/spec_sort.hpp>
 #include <util/error.hpp>
+#include <util/io/package_manager.hpp>
 #include <data/set.hpp>
 #include <data/card.hpp>
 #include <data/game.hpp>
@@ -62,6 +63,12 @@ SCRIPT_FUNCTION(error) {
     queue_message(MESSAGE_ERROR, input);
   }
   return script_nil;
+}
+
+SCRIPT_FUNCTION(exists_in_package) {
+  SCRIPT_PARAM_C(String, input);
+  bool result = package_manager.existsInPackage(input);
+  SCRIPT_RETURN(result);
 }
 
 // ----------------------------------------------------------------------------- : Conversion
@@ -738,6 +745,7 @@ void init_script_basic_functions(Context& ctx) {
   ctx.setVariable(_("trace"),                script_trace);
   ctx.setVariable(_("warning"),              script_warning);
   ctx.setVariable(_("error"),                script_error);
+  ctx.setVariable(_("exists_in_package"),    script_exists_in_package);
   // conversion
   ctx.setVariable(_("to_string"),            script_to_string);
   ctx.setVariable(_("to_int"),               script_to_int);

--- a/src/util/io/package.hpp
+++ b/src/util/io/package.hpp
@@ -132,10 +132,16 @@ public:
 
   // --------------------------------------------------- : Managing the inside of the package
 
+  /// Check if a file is in the package.
+  bool existsIn(const String& file);
+  inline bool existsIn(const LocalFileName& file) {
+      return existsIn(file.fn);
+  }
+
   /// Open an input stream for a file in the package.
   unique_ptr<wxInputStream> openIn(const String& file);
   inline unique_ptr<wxInputStream> openIn(const LocalFileName& file) {
-    return openIn(file.fn);
+      return openIn(file.fn);
   }
 
   /// Open an output stream for a file in the package.

--- a/src/util/io/package_manager.cpp
+++ b/src/util/io/package_manager.cpp
@@ -95,6 +95,20 @@ void PackageManager::findMatching(const String& pattern, vector<PackagedP>& out)
   }
 }
 
+bool PackageManager::existsInPackage(const String& name) {
+  if (!name.empty() && name.GetChar(0) == _('/')) {
+    // break name
+    size_t start = name.find_first_not_of(_("/\\"), 1); // allow "//package/name" from incorrect scripts
+    size_t pos = name.find_first_of(_("/\\"), start);
+    if (start < pos && pos != String::npos) {
+      // open package
+      PackagedP p = openAny(name.substr(start, pos - start));
+      return p->existsIn(name.substr(pos + 1));
+    }
+  }
+  throw FileNotFoundError(name, _("No package name specified, use '/package/filename'"));
+}
+
 pair<unique_ptr<wxInputStream>,Packaged*> PackageManager::openFileFromPackage(Packaged* package, const String& name) {
   if (!name.empty() && name.GetChar(0) == _('/')) {
     // absolute name; break name

--- a/src/util/io/package_manager.hpp
+++ b/src/util/io/package_manager.hpp
@@ -139,7 +139,10 @@ public:
   /// Find all packages that match a filename pattern, store them in out
   /** Only reads the package headers */
   void findMatching(const String& pattern, vector<PackagedP>& out);
-  
+
+  /// Check if a file exists in a package
+  bool existsInPackage(const String& name);
+
   /// Open a file from a package, with a name encoded as "/package/file"
   /** If 'package' is set then:
    *    - tries to open a relative file from the package if the name is "file"
@@ -148,7 +151,7 @@ public:
    *  Returns the opened file and the package it is in
    */
   pair<unique_ptr<wxInputStream>,Packaged*> openFileFromPackage(Packaged* package, const String& name);
-  
+
   /// Get a filename to open from a package
   /** WARNING: this is a bit of a hack, since not all package types support names in this way.
    *  It is needed for third party libraries (i.e. hunspell) that load stuff from files.

--- a/tools/website/drupal/mse-drupal-modules/highlight.inc
+++ b/tools/website/drupal/mse-drupal-modules/highlight.inc
@@ -101,6 +101,7 @@ $built_in_functions = array(
 	// other
 	'trace'			=>'',
 	'assert'		=>'',
+	'exists_in_package'		=>'',
 );
 
 


### PR DESCRIPTION
Looking for a code review. I'm trying to implement a script function that will check if a file in is a package.

Currently there is no way of doing this, apart from trying to load the file, which will throw an error if it doesn't exist.

I think the logic is correct (it gives the expected result), but as I am not a C++ dev, I'm worried I might be doing something wrong like leaking resources. Specifically, it seems like some code paths open file input streams, which might need to be closed?

I modeled the `existsIn` function in `package.cpp` after the `openIn` function next to it, as I want the `existsIn` function to return false whenever the `openIn` function throws.