### PR TITLE
Take margin_right into account when determining line width

### DIFF
--- a/src/render/text/viewer.cpp
+++ b/src/render/text/viewer.cpp
@@ -613,7 +613,7 @@ bool TextViewer::prepareLinesAtScale(RotatedDC& dc, const vector<CharInfo>& char
     }
     // Did the word become too long?
     if (!break_now) {
-      double max_width = lineRight(dc, style, line.top);
+      double max_width = lineRight(dc, style, line.top) - line.margin_right;
       if (line_size.width + word_size.width > max_width) {
         if (!style.field().multi_line) {
           // single line word does not fit


### PR DESCRIPTION
The `<margin:>` tag's right value was ignored.