### PR TITLE
Exempt symbol-fonts from dependency checks

### DIFF
--- a/src/util/io/package.cpp
+++ b/src/util/io/package.cpp
@@ -644,6 +644,8 @@ void Packaged::requireDependency(Packaged* package) {
       }
     }
   }
+  // skip dependency checks for symbol-fonts
+  if (package->relativeFilename().find("mse-symbol-font") != std::string::npos) return;
   // dependency not found
   queue_message(MESSAGE_WARNING,_ERROR_4_("dependency not given", name(), package->relativeFilename(), package->relativeFilename(), package->version.toString()));
 }


### PR DESCRIPTION
Symbol-fonts can be changed by the end user, so it doesn't make sense to require templates to list them as dependencies.