### PR TITLE
Fix #93 crash on Windows

### DIFF
--- a/src/gui/control/item_list.cpp
+++ b/src/gui/control/item_list.cpp
@@ -180,10 +180,10 @@ void ItemList::refreshList(bool refresh_current_only) {
   // refresh
   // Note: Freeze/Thaw makes flicker worse
   long item_count = (long)sorted_list.size();
+  SetItemCount(item_count);
   if (item_count == 0) {
     Refresh();
   } else {
-    SetItemCount(item_count);
     // (re)select current item
     findSelectedItemPos();
     focusNone();


### PR DESCRIPTION
moving SetItemCount above the Refresh() prevents the crash from #93 on Windows, and still avoids the original crash from #57 (checked by halian). It looks like the #93 crash is still occurring on Linux, but it is doing this already, and i don't have a great way to test fixes for that.