### PR TITLE
add global scope variables

### DIFF
--- a/src/script/context.hpp
+++ b/src/script/context.hpp
@@ -54,6 +54,7 @@ public:
   void setVariable(const String& name, const ScriptValueP& value);
   /// Set a variable to a new value (in the current scope)
   void setVariable(Variable name, const ScriptValueP& value);
+  void setGlobalVariable(Variable name, const ScriptValueP& value);
   
   /// Get the value of a variable, throws if it not set
   ScriptValueP getVariable(const String& name);
@@ -89,6 +90,7 @@ public:// public for FOR_EACH
     VariableValue() : level(0) {}
     unsigned int level; ///< Scope level on which this variable was set
     ScriptValueP value; ///< Value of this variable
+    bool global_scope = false; ///< Is this variable globally scoped? 
   };
   /// Record of a variable binding that is being shadowed (overwritten) by another binding
   struct Binding {

--- a/src/script/dependency.cpp
+++ b/src/script/dependency.cpp
@@ -301,6 +301,11 @@ ScriptValueP Context::dependencies(const Dependency& dep, const Script& script) 
           setVariable((Variable)i.data, stack.back());
           break;
         }
+        // Set a global variable (as normal)
+        case I_SET_GLB: {
+          setGlobalVariable((Variable)i.data, stack.back());
+          break;
+        }
         
         // Simple instruction: unary
         case I_UNARY: {

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -176,6 +176,7 @@ String Script::dumpInstr(unsigned int pos, Instruction i) const {
     case I_JUMP_SC_OR:  ret += _("jump sc or");  break;
     case I_GET_VAR:    ret += _("get");    break;
     case I_SET_VAR:    ret += _("set");    break;
+    case I_SET_GLB:    ret += _("set_global");    break;
     case I_MEMBER_C:  ret += _("member_c");  break;
     case I_LOOP:    ret += _("loop");    break;
     case I_LOOP_WITH_KEY:ret += _("loop with key"); break;
@@ -236,7 +237,7 @@ String Script::dumpInstr(unsigned int pos, Instruction i) const {
     case I_CALL: case I_CLOSURE: case I_DUP:  // int
       ret += String::Format(_("\t%d"), i.data);
       break;
-    case I_GET_VAR: case I_SET_VAR: case I_NOP:          // variable
+    case I_GET_VAR: case I_SET_VAR: case I_NOP: case I_SET_GLB:          // variable
       ret += _("\t") + variable_to_string((Variable)i.data);
       break;
   }

--- a/src/script/script.hpp
+++ b/src/script/script.hpp
@@ -30,6 +30,7 @@ enum InstructionType
   // Variables
 ,  I_GET_VAR       = 4  ///< arg = var        : find a variable, push its value onto the stack, it is an error if the variable is not found
 ,  I_SET_VAR       = 5  ///< arg = var        : assign the top value from the stack to a variable (doesn't pop)
+,  I_SET_GLB       = 21 ///< arg = var        : assign the top value from the stack to a global variable (doesn't pop)
   // Objects
 ,  I_MEMBER_C      = 6  ///< arg = const name : finds a member of the top of the stack replaces the top of the stack with the member
 ,  I_LOOP          = 7  ///< arg = address    : loop over the elements of an iterator, which is the *second* element of the stack (this allows for combing the results of multiple iterations)


### PR DESCRIPTION
* Adds the -> operator, `variable_name -> variable_definition`
* Defining or redefining a variable with the -> operator causes it to become "globally scoped" rather than dynamically scoped. Changes to the variable at any level are retained, letting games/styles cache more expensive operations or use more permanent storage.
* Once a variable is globally scoped, it is always. `variable := value` will be valid and update it globally.
* I tried to make it so if a variable was initially declared with `:=` instead of `->`, it would be unable to be global, but i was unable to make it work