### PR TITLE
Fix print overlap bug

### DIFF
--- a/src/gui/print_window.cpp
+++ b/src/gui/print_window.cpp
@@ -143,7 +143,8 @@ void CardsPrintout::drawCard(DC& dc, const CardP& card, int card_nr) {
   int w = int(stylesheet.card_width), h = int(stylesheet.card_height); // in pixels
   if (is_rad90(rotation)) swap(w,h);
   // Draw using text buffer
-  double zoom = IsPreview() ? 1 : 4;
+  bool isPreview = IsPreview();
+  double zoom = isPreview ? 1 : 4;
   wxBitmap buffer(w*zoom,h*zoom,32);
   wxMemoryDC bufferDC;
   bufferDC.SelectObject(buffer);
@@ -157,7 +158,7 @@ void CardsPrintout::drawCard(DC& dc, const CardP& card, int card_nr) {
   dc.SetUserScale(scale_x / px_per_mm, scale_y / px_per_mm);
   dc.SetDeviceOrigin(int(scale_x * pos.x), int(scale_y * pos.y));
   bufferDC.SelectObject(wxNullBitmap);
-  dc.DrawBitmap(buffer, 0, 0);
+  dc.DrawBitmap(buffer, isPreview ? 0 : int(scale_x * pos.x), isPreview ? 0 : int(scale_y * pos.y));
 }
 
 // ----------------------------------------------------------------------------- : PrintWindow

--- a/src/gui/print_window.hpp
+++ b/src/gui/print_window.hpp
@@ -26,7 +26,8 @@ public:
   // layout
   RealSize page_size;      ///< Size of a page (in millimetres)
   RealSize card_size;      ///< Size of a card (in millimetres)
-  RealSize card_spacing;    ///< Spacing between cards (in millimetres)
+  RealSize card_spacing;   ///< Spacing between cards (in millimetres)
+  double card_dpi;         ///< Dots per inch of the default stylesheet
   double margin_left, margin_right, margin_top, margin_bottom; ///< Page margins (in millimetres)
   int rows, cols;        ///< Number of rows/columns of cards
   bool card_landscape;    ///< Are cards rotated to landscape orientation?


### PR DESCRIPTION
This fixes the bug where all the cards are printed on top of each other.
This bug apparently only occurs on the latest versions of the dependencies, probably wxWidgets in particular.
I have no idea why this fix works.

Also, if you are NOT using the latest versions, then this might actually break the printing process. (I don't know how to test this.) So it might actually be a bad idea to merge this.