### PR TITLE
font rendering/exporting without installing system-wide

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -64,7 +64,14 @@
       "cmakeCommandArgs": "-DVCPKG_TARGET_TRIPLET=x64-windows-static",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": "",
-      "inheritEnvironments": [ "msvc_x64_x64" ]
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": [
+        {
+          "name": "VCPKG_MANIFEST_FEATURES",
+          "value": "fonts",
+          "type": "STRING"
+        }
+      ]
     }
   ]
 }

--- a/src/data/font.hpp
+++ b/src/data/font.hpp
@@ -46,9 +46,11 @@ public:
   double             shadow_blur;          ///< Blur radius of the shadow
   Color              separator_color;      ///< Color for <sep> text
   int                flags;                ///< FontFlags for this font
-  
+
   Font();
-  
+
+  /// Load fonts (.ttf) from the resource/fonts directory
+  static bool PreloadResourceFonts();   
   /// Update the scritables, returns true if there is a change
   bool update(Context& ctx);
   /// Add the given dependency to the dependent_scripts list for the variables this font depends on
@@ -64,7 +66,7 @@ public:
   
   /// Convert this font to a wxFont
   wxFont toWxFont(double scale) const;
-  
+
 private:
   DECLARE_REFLECTION();
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include <data/locale.hpp>
 #include <data/installer.hpp>
 #include <data/format/formats.hpp>
+#include <data/font.hpp>
 #include <cli/cli_main.hpp>
 #include <cli/text_io_handler.hpp>
 #include <gui/welcome_window.hpp>
@@ -86,6 +87,7 @@ int MSE::OnRun() {
       // Platform friendly appname
       SetAppName(_("magicseteditor"));
     #endif
+    Font::PreloadResourceFonts();
     wxInitAllImageHandlers();
     wxFileSystem::AddHandler(new wxInternetFSHandler); // needed for update checker
     wxSocketBase::Initialize();


### PR DESCRIPTION
Allows fonts in the `resource/fonts` folder to be properly displayed and exported, no system-wide font installations required! I can't confirm that this works on builds other than `x64-windows-static`, but I can confirm that it will not work on Unix systems, as those require extra dependencies for the wxWidgets private fonts.

No required fonts installed system-wide & no `resource/fonts` folder:

![image](https://github.com/user-attachments/assets/ee631c67-0b77-4c5d-bc40-cb1332f88db7)

No required fonts installed system-wide, but **has** a `resource/fonts` folder:

![image](https://github.com/user-attachments/assets/95e1e061-4c82-48d4-a082-50ae54a26315)
